### PR TITLE
Indicate a recurring billing method to indicate CVV is not expected

### DIFF
--- a/lib/active_merchant/billing/gateways/network_merchants.rb
+++ b/lib/active_merchant/billing/gateways/network_merchants.rb
@@ -176,6 +176,7 @@ module ActiveMerchant #:nodoc:
           post[:payment] = 'creditcard'
         else
           post[:customer_vault_id] = payment_source
+          post[:billing_method] = 'recurring'
         end
       end
 

--- a/test/unit/gateways/network_merchants_test.rb
+++ b/test/unit/gateways/network_merchants_test.rb
@@ -147,7 +147,9 @@ class NetworkMerchantsTest < Test::Unit::TestCase
   end
 
   def test_purchase_on_stored_card
-    @gateway.expects(:ssl_post).returns(successful_purchase_on_stored_card)
+    @gateway.expects(:ssl_post).with do |_, body|
+      body.include?("billing_method=recurring")
+    end.returns(successful_purchase_on_stored_card)
 
     assert purchase = @gateway.purchase(@amount, 1200085822, @options)
     assert_success purchase


### PR DESCRIPTION
From NMI: "It looks like there is an indication that can be submitted
with the transaction that will indicate it is a recurring charge (not
a first time charge) and it should not expect the CVV to be passed.
The “billing-method” will need to be indicated as “recurring” when the
sale is passed through the API"

This is not a problem for most customers but fails for Optimal
Payments, in particular.
